### PR TITLE
Equiplet node

### DIFF
--- a/libraries/mast/include/Mast/HardwareModuleProperties.h
+++ b/libraries/mast/include/Mast/HardwareModuleProperties.h
@@ -34,14 +34,17 @@
 #include "rosMast/StateMachine.h"
 
 namespace Mast {
+	/** 
+	 * HardwareModuleProperties defines the the data that is for a module
+	 **/
 	class HardwareModuleProperties {
 	public:
 		HardwareModuleProperties();
 		/**
 		 * Create a new hardware module
 		 * 
-		 * @param id unique identifier of the module
-		 * @param type type of the module
+		 * @param id Unique identifier of the module
+		 * @param type Defines the type of the module
 		 * @param state The current state of this module
 		 * @param actuator Is this module an actor
 		 * @param needed Is this module needed for the current service
@@ -49,30 +52,36 @@ namespace Mast {
 		HardwareModuleProperties(int id, int type, rosMast::StateType state, bool actuator, bool needed):
 			id(id), type(type), currentState(state), actuator(actuator), needed(needed), error(false){}
 		/**
+		 * @var int id
 		 * The id of the module
 		 **/
 		int id;
 		/** 
+		 * @var int type
 		 * The type of the module 
-		 *
 		 **/
 		int type;
 		/**
+		 * @var rosMast::StateType currentState
 		 *  The currentState of the module
 		 **/
 		rosMast::StateType currentState;
 		/**
+		 * @var bool actuator
 		 * Defines if the hardware module is an actuator
 		 **/
 		bool actuator;		
 		/**
+		 * @var bool needed
 		 * defines if the hardware module is needed for the current service
 		 **/
 		bool needed;
 		/**
+		 * @var bool error
 		 * shows if the modules is in an error state
 		 **/
 		bool error;
+		
 		friend std::ostream& operator<<(std::ostream& stream, HardwareModuleProperties &module) {
 			stream << "Id: " << module.id << ", current state: " << module.currentState << " actuator " << module.actuator << " Required for current service " << module.needed;
 			return stream;

--- a/libraries/mast/include/Mast/HardwareModuleProperties.h
+++ b/libraries/mast/include/Mast/HardwareModuleProperties.h
@@ -26,6 +26,9 @@
 * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 
+#ifndef HWMODULEPROPERTIES_H
+#define HWMODULEPROPERTIES_H
+
 #include <string>
 #include <iostream>
 #include "rosMast/StateMachine.h"
@@ -46,17 +49,29 @@ namespace Mast {
 		HardwareModuleProperties(int id, int type, rosMast::StateType state, bool actuator, bool needed):
 			id(id), type(type), currentState(state), actuator(actuator), needed(needed), error(false){}
 		/**
-		 * The use of a name for a module is a temporary solution. 
-		 * This will probably be changed when the module database is implemented.
+		 * The id of the module
 		 **/
 		int id;
+		/** 
+		 * The type of the module 
+		 *
+		 **/
 		int type;
+		/**
+		 *  The currentState of the module
+		 **/
 		rosMast::StateType currentState;
+		/**
+		 * Defines if the hardware module is an actuator
+		 **/
 		bool actuator;		
 		/**
 		 * defines if the hardware module is needed for the current service
 		 **/
 		bool needed;
+		/**
+		 * shows if the modules is in an error state
+		 **/
 		bool error;
 		friend std::ostream& operator<<(std::ostream& stream, HardwareModuleProperties &module) {
 			stream << "Id: " << module.id << ", current state: " << module.currentState << " actuator " << module.actuator << " Required for current service " << module.needed;
@@ -64,3 +79,5 @@ namespace Mast {
 		}
 	};
 }
+
+#endif

--- a/libraries/motor/src/StepperMotor.cpp
+++ b/libraries/motor/src/StepperMotor.cpp
@@ -67,9 +67,8 @@ namespace Motor
             modbus->writeU16(motorIndex, CRD514KD::Registers::OP_SEQ_MODE + 1, /*1*/
             0);
             modbus->writeU16(motorIndex, CRD514KD::Registers::CMD_1, CRD514KD::CMD1Bits::EXCITEMENT_ON);
-            //set motors limits
 
-            std::cout << "[DEBUG] poweron " << (uint32_t)((minAngle + deviation) / CRD514KD::MOTOR_STEP_ANGLE) << "  " << minAngle << "  " << deviation << std::endl;
+            //set motors limits
             modbus->writeU32(motorIndex, CRD514KD::Registers::CFG_POSLIMIT_POSITIVE, (uint32_t)((maxAngle + deviation) / CRD514KD::MOTOR_STEP_ANGLE));
             modbus->writeU32(motorIndex, CRD514KD::Registers::CFG_POSLIMIT_NEGATIVE, (uint32_t)((minAngle + deviation) / CRD514KD::MOTOR_STEP_ANGLE));
             modbus->writeU32(motorIndex, CRD514KD::Registers::CFG_START_SPEED, 1);
@@ -217,7 +216,6 @@ namespace Motor
     {
     	this->minAngle = minAngle;
         modbus->writeU32(motorIndex, CRD514KD::Registers::CFG_POSLIMIT_NEGATIVE, (uint32_t)((minAngle + deviation) / CRD514KD::MOTOR_STEP_ANGLE));
-        std::cout << "[DEBUG] setMinAngle " << (uint32_t)((minAngle + deviation) / CRD514KD::MOTOR_STEP_ANGLE) << "  " << minAngle << std::endl;
         anglesLimited = true;
     }
 

--- a/libraries/utilities/include/Utilities/Utilities.h
+++ b/libraries/utilities/include/Utilities/Utilities.h
@@ -40,7 +40,7 @@ namespace Utilities
     void sleep(long ms);
     double deg(double rad);
     double rad(double deg);
-    int str2int(int &i, char const *s, int base = 0);
+    int stringToInt(int &i, char const *s, int base = 0);
 
     /**
      * Utility class to time stuff

--- a/libraries/utilities/src/Utilities.cpp
+++ b/libraries/utilities/src/Utilities.cpp
@@ -87,12 +87,12 @@ namespace Utilities
      * @param base A value between 2 and 36 inclusive, which determines the base of the value in the string. Special value is 0, which takes the value as base 10 unless a prefix of 0x (hexadecimal) or 0 (octal).
      *
      * @return error code
-     *  0 is normal
-     *  1 is overflow
-     *  2 is underflow
-     *  3 is inconvertible
+     *  - 0 is normal
+     *  - 1 is overflow
+     *  - 2 is underflow
+     *  - 3 is inconvertible
      **/
-    int str2int(int &i, char const *s, int base) {
+    int stringToInt(int &i, char const *s, int base) {
         char *end;
         long  l;
         errno = 0;

--- a/ros/deltaRobotNode/src/DeltaRobotNode.cpp
+++ b/ros/deltaRobotNode/src/DeltaRobotNode.cpp
@@ -344,6 +344,7 @@ int deltaRobotNodeNamespace::DeltaRobotNode::transitionSetup() {
 int deltaRobotNodeNamespace::DeltaRobotNode::transitionShutdown() {	
 	ROS_INFO("Shutdown transition called");	
 	setState(rosMast::shutdown);
+	// Should have information about the workspace, calculate a safe spot and move towards it
 	deltaRobot->powerOff();
 	return 0;
 }
@@ -364,10 +365,10 @@ int deltaRobotNodeNamespace::DeltaRobotNode::transitionStart() {
  * @return will be 0 if everything went ok else error
  **/
 int deltaRobotNodeNamespace::DeltaRobotNode::transitionStop() {
-	ROS_INFO("Stop transition called");
-	
+	ROS_INFO("Stop transition called");	
 	// Set currentState to stop
 	setState(rosMast::stop);
+	// Go to base (Motors on 0 degrees)
 	return 0;
 }
 

--- a/ros/deltaRobotNode/src/DeltaRobotNode.cpp
+++ b/ros/deltaRobotNode/src/DeltaRobotNode.cpp
@@ -329,6 +329,7 @@ int deltaRobotNodeNamespace::DeltaRobotNode::transitionSetup() {
     deltaRobot->generateBoundaries(2);
 	// Power on the deltarobot and calibrate the motors.
     deltaRobot->powerOn();
+    // Calibrate the motors
     if(!deltaRobot->calibrateMotors()){
     	ROS_ERROR("Calibration FAILED. EXITING.");
     	return 1;
@@ -355,9 +356,9 @@ int deltaRobotNodeNamespace::DeltaRobotNode::transitionShutdown() {
  **/
 int deltaRobotNodeNamespace::DeltaRobotNode::transitionStart() {
 	ROS_INFO("Start transition called");   
-
 	// Set currentState to start
 	setState(rosMast::start);	
+	// Could calibrate here
 	return 0;
 }
 /**

--- a/ros/deltaRobotNode/src/DeltaRobotNode.cpp
+++ b/ros/deltaRobotNode/src/DeltaRobotNode.cpp
@@ -382,7 +382,7 @@ int main(int argc, char **argv) {
 	deltaRobotNodeNamespace::DeltaRobotNode drn(equipletID, moduleID);    
 	
 	ROS_INFO("Running StateEngine"); 	
-    drn.StateEngine();	
+    drn.startStateMachine();	
 	return 0;
 }
 

--- a/ros/deltaRobotNode/src/DeltaRobotNode.cpp
+++ b/ros/deltaRobotNode/src/DeltaRobotNode.cpp
@@ -374,10 +374,15 @@ int deltaRobotNodeNamespace::DeltaRobotNode::transitionStop() {
 }
 
 int main(int argc, char **argv) {
-	ros::init(argc, argv, NODE_NAME);
+	int equipletID;
+	int moduleID;
+	
+	if(argc < 3 || 	(Utilities::stringToInt(equipletID, argv[1])!= 0 && Utilities::stringToInt(moduleID, argv[2]) != 0)) 
+	{
+		return -1;
+	}
 
-	int equipletID = atoi(argv[1]);
-	int moduleID = atoi(argv[2]);
+	ros::init(argc, argv, NODE_NAME);
 
 	ROS_INFO("Creating DeltaRobotNode"); 	
 

--- a/ros/equipletNode/src/EquipletNode.cpp
+++ b/ros/equipletNode/src/EquipletNode.cpp
@@ -72,10 +72,10 @@ void EquipletNode::stateChanged(const rosMast::StateChangedPtr &msg) {
  * @param msg Contains a errorCode and the ID of the module were the error occured
  **/
 void EquipletNode::moduleErrorCallback(const rosMast::ModuleErrorPtr &msg) {
-	//int errorCode = msg->errorCode;
 	int moduleID = msg->moduleID;
+	//int errorCode = msg->errorCode;
 
-	// Lookup errorcode in the DB and decide accordingly
+	// TODO: Lookup errorcode in the DB and decide accordingly
 	
 	// Lookup current state of the module
 	rosMast::StateType currentModuleState = getModuleState(moduleID);
@@ -124,21 +124,17 @@ void EquipletNode::updateOperationState() {
 	rosMast::StateType newOperationState = rosMast::normal;
 
 	for(it = moduleTable.begin(); it < moduleTable.end(); it++) {
-		/**
-		 * Set the new operation state if the hardware module is an actor, required for
-		 * the current service and if its state is lower than the new operation state as
-		 * initialized above.
-		 **/
+		 // Set the new operation state if the hardware module is an actor, required for
+		 // the current service and if its state is lower than the new operation state as
+		 // Initialized above.
 		if((*it).actuator && (*it).needed) {
 			newOperationState = std::min((*it).currentState, newOperationState);
 			operationStateSet = true;
 		}
 	}
-	/**
-	 * If the operation state is not set, it means that there are no actor modules suited
-	 * for the current service and so the operation state is equal to the lowest state possible
-	 * the safe state.
-	 **/
+	// If the operation state is not set, it means that there are no actor modules suited
+	// for the current service and so the operation state is equal to the lowest state possible
+	// the safe state.
 	if(!operationStateSet) {
 		newOperationState = rosMast::safe;
 	}
@@ -153,9 +149,7 @@ void EquipletNode::updateOperationState() {
  * @return true if the module has a unique id, otherwise false
  **/
 bool EquipletNode::addHardwareModule(Mast::HardwareModuleProperties module) {
-	/**
-	 * First check if the module already exists
-	 **/
+	// First check if the module already exists
 	std::vector<Mast::HardwareModuleProperties>::iterator it;
 	for(it = moduleTable.begin(); it < moduleTable.end(); it++) {
 		if(module.id == (*it).id) {
@@ -163,9 +157,7 @@ bool EquipletNode::addHardwareModule(Mast::HardwareModuleProperties module) {
 		}
 	}
 
-	/**
-	 * Create the string that is used to start another ROS node
-	 **/ 
+    // Create the string that is used to start another ROS node	 
 	std::pair< std::string, std::string > packageNodeName = modulePackageNodeMap[module.type];
 	std::stringstream ss(std::stringstream::in | std::stringstream::out);
 	ss << "rosrun " << packageNodeName.first << " " << packageNodeName.second << " " << equipletId << " " << module.id;
@@ -184,9 +176,8 @@ bool EquipletNode::addHardwareModule(Mast::HardwareModuleProperties module) {
 			break; 
 	}
 
-	/**
-	 * Add the module to the table and update the safety state and operation state	
-	 **/
+	
+	// Add the module to the table and update the safety state and operation state	
 	moduleTable.push_back(module);
 	updateSafetyState();
 	updateOperationState(); 

--- a/ros/equipletNode/src/EquipletNode.cpp
+++ b/ros/equipletNode/src/EquipletNode.cpp
@@ -36,7 +36,7 @@
 
 /**
  * Create a new EquipletNode
- * @var id The unique identifier of the Equiplet
+ * @param id The unique identifier of the Equiplet
  **/
 EquipletNode::EquipletNode(int id): equipletId(id), moduleTable() {
 	// Create the map with moduleType mapped to package name and node name

--- a/ros/equipletNode/src/EquipletNode.cpp
+++ b/ros/equipletNode/src/EquipletNode.cpp
@@ -168,7 +168,7 @@ bool EquipletNode::addHardwareModule(Mast::HardwareModuleProperties module) {
 	 **/ 
 	std::pair< std::string, std::string > packageNodeName = modulePackageNodeMap[module.type];
 	std::stringstream ss(std::stringstream::in | std::stringstream::out);
-	ss << "rosrun " << packageNodeName.first << " " << packageNodeName.second << " " << equipletId << " " << module.id; // << " __name:=" << packageNodeName.second;
+	ss << "rosrun " << packageNodeName.first << " " << packageNodeName.second << " " << equipletId << " " << module.id;
 	std::cout << ss.str() << std::endl;
 	int pid = -1;
 	switch(pid = fork()) {

--- a/ros/equipletNode/src/Main.cpp
+++ b/ros/equipletNode/src/Main.cpp
@@ -28,23 +28,19 @@
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#include <EquipletNode/EquipletNode.h>
 #include "ros/ros.h"
+#include <EquipletNode/EquipletNode.h>
 #include <Utilities/Utilities.h>
 
 int main(int argc, char **argv) {
 
-	/**
-	 * Check if an equiplet id is given at the command 	line
-	 **/
+	// Check if an equiplet id is given at the command line	 
 	int equipletId = 1;
-	if(argc != 2 || Utilities::str2int(equipletId, argv[1]) != 0) {
+	if(argc != 2 || Utilities::stringToInt(equipletId, argv[1]) != 0) {
 		std::cerr << "Cannot read equiplet id from commandline. Assuming equiplet id is 1" <<std::endl;
-	} 
-
-	/**
-	 * Set the id of the Equiplet
-	 **/
+	}
+	 	
+	// Set the id of the Equiplet
 	std::ostringstream ss;
 	ss << "Equiplet" << equipletId;
 	const char* equipletName = ss.str().c_str();
@@ -52,18 +48,15 @@ int main(int argc, char **argv) {
 	ros::init(argc, argv, equipletName);
 	EquipletNode * equipletNode = new EquipletNode(equipletId);
 
-	/**
-	 * Add some hardware modules to this equiplet
-	 * This should change to modules being created in the Node itself after commands on blackboard
-	 **/
+	// Add some hardware modules to this equiplet
+	// This should change to modules being created in the Node itself after commands on blackboard
 	Mast::HardwareModuleProperties deltaRobot(1, 1, rosMast::safe, true, true);
 	Mast::HardwareModuleProperties gripper(2, 2, rosMast::safe, true, true);
 	equipletNode->addHardwareModule(deltaRobot);
 	equipletNode->addHardwareModule(gripper);
 
-	/**
-	 * print the hardware modules that are currently added to the Equiplet
-	 **/
+	
+	// print the hardware modules that are currently added to the Equiplet
 	equipletNode->printHardwareModules();
 	
 	ros::Rate poll_rate(10);
@@ -72,9 +65,7 @@ int main(int argc, char **argv) {
 		ros::spinOnce();	
 	}
 
-	/**
-	 * Delete the EquipletNode pointer
-	 **/
+	// Delete the EquipletNode pointer	
 	delete equipletNode;
 
 	return 0;

--- a/ros/rosMast/include/rosMast/StateMachine.h
+++ b/ros/rosMast/include/rosMast/StateMachine.h
@@ -80,9 +80,25 @@ namespace rosMast {
 		public:
 			StateMachine(int equipletID, int moduleID);	
 		
+			/**
+			 * Transition from Safe to Standby
+			 * @return 0 if everything when succesfull
+			 **/
 			virtual int transitionSetup() = 0;
+			/**
+			 * Transition from Standby to Ssafe
+			 * @return 0 if everything when succesfull
+			 **/
 			virtual int transitionShutdown() = 0;
+			/**
+			 * Transition from Standby to Normal
+			 * @return 0 if everything when succesfull
+			 **/			
 			virtual int transitionStart() = 0;
+			/**
+			 * Transition from Normal to Standby
+			 * @return 0 if everything when succesfull
+			 **/			
 			virtual int transitionStop() = 0;
 
 			StateType getState() { return currentState; }	
@@ -92,7 +108,7 @@ namespace rosMast {
 			stateFunctionPtr lookupTransition(StateType currentState, StateType desiredState);
 			void sendErrorMessage(int errorCode);
 			
-			void StateEngine();			
+			void startStateMachine();			
 		private:
 			/**
 			 * @var std::map<StateTransition, stateFunctionPtr> transitionMap;

--- a/ros/rosMast/include/rosMast/StateMachine.h
+++ b/ros/rosMast/include/rosMast/StateMachine.h
@@ -35,6 +35,9 @@
 #include "rosMast/ModuleError.h"
 #include "rosMast/States.h"
 
+/**
+ * The size of the Transition table
+ **/
 #define TRANSITION_TABLE_SIZE 4
 
 namespace rosMast {
@@ -50,10 +53,12 @@ namespace rosMast {
 			destinationState = des;
 		}
 		/**
+		 * @var StateType sourceState
 		 * The original state
 		 **/
 		StateType sourceState;
 		/**
+		 * @var StateType destinationState
 		 * Destination state for transition
 		 **/
 		StateType destinationState;
@@ -100,8 +105,12 @@ namespace rosMast {
 			 * @return 0 if everything when succesfull
 			 **/			
 			virtual int transitionStop() = 0;
-
+			/**
+			 * Get the state of the statemachine
+			 * @return the currentState of the machine
+			 **/
 			StateType getState() { return currentState; }	
+			
 			void setState( StateType newState );				
 			void changeState(const rosMast::StateChangedPtr &msg);			
 			

--- a/ros/rosMast/msg/StateChanged.msg
+++ b/ros/rosMast/msg/StateChanged.msg
@@ -1,3 +1,3 @@
 int32 equipletID
 int32 moduleID
-int32  state
+int32 state

--- a/ros/rosMast/src/StateMachine.cpp
+++ b/ros/rosMast/src/StateMachine.cpp
@@ -144,7 +144,7 @@ void rosMast::StateMachine::sendErrorMessage(int errorCode) {
 /** 
  * The run part of the state machine
  **/
-void rosMast::StateMachine::StateEngine() {
+void rosMast::StateMachine::startStateMachine() {
 	while(ros::ok()) { 
 		ros::spinOnce();
 	}

--- a/tools/gripperTestNode/include/Gripper.h
+++ b/tools/gripperTestNode/include/Gripper.h
@@ -32,7 +32,7 @@
 
 /**
  * Gripper device
- * Gripper valve could be overheated. A watchdog is running to check the valve is not opened for too long.
+ * Gripper valve could overheat, a watchdog is running to check the valve is not opened for too long so it won't heat.
  **/
 class Gripper {
 	/**
@@ -46,15 +46,15 @@ class Gripper {
 	/**
 	 * @var static int GRIPPER_MODBUS_ADRESS
 	 * Register containing the bit (port) for the gripper device
-	 * TODO: Should be moved into a dynamic location? QRCODE / Database?
 	 **/
+	// TODO: Should be moved into a dynamic location? QRCODE / Database?
 	const static int GRIPPER_MODBUS_ADRESS = 8001;
 
 	/**
 	 * @var static int GRIPPER_DEVICE_PIN
 	 * Pin (port / bit) of the gripper device
-	 * TODO: Should be moved into a dynamic location? QRCODE / Database?
 	 **/
+	// TODO: Should be moved into a dynamic location? QRCODE / Database?
 	const static int GRIPPER_DEVICE_PIN = 1;
 
 	/**
@@ -78,8 +78,8 @@ class Gripper {
 	/**
 	 * @var static int GRIPPER_TIME_WATCHDOG_INTERVAL
 	 * Watchdog loop interval.
-	 * TODO: tune for optimal performance?
 	 **/
+	// TODO: tune for optimal performance?
 	const static int GRIPPER_TIME_WATCHDOG_INTERVAL = 100;
 
 	Gripper(void* GripperNode, watchdogWarningHandler warningHandler);

--- a/tools/gripperTestNode/include/Gripper.h
+++ b/tools/gripperTestNode/include/Gripper.h
@@ -31,8 +31,8 @@
 #include <boost/thread.hpp>
 
 /**
- * Gripper device
- * Gripper valve could overheat, a watchdog is running to check the valve is not opened for too long so it won't heat.
+ * Interface to the hardware, so the gripper can go on and off
+ * Gripper valve could overheat, a watchdog is running to check the valve is not opened for too long so it won't overheat.
  **/
 class Gripper {
 	/**

--- a/tools/gripperTestNode/include/Gripper.h
+++ b/tools/gripperTestNode/include/Gripper.h
@@ -85,10 +85,15 @@ class Gripper {
 	Gripper(void* GripperNode, watchdogWarningHandler warningHandler);
 	virtual ~Gripper();
 
+	/** 
+	 * Turn the gripper on
+	 **/
 	void grab(){
 		state = true;
 	}
-
+	/** 
+	 * Turn the gripper off
+	 **/
 	void release(){
 		state = false;
 	}

--- a/tools/gripperTestNode/src/GripperTestNode.cpp
+++ b/tools/gripperTestNode/src/GripperTestNode.cpp
@@ -4,8 +4,6 @@
 
 /**
  * Constructor 
- *
- *
  **/
 GripperTestNode::GripperTestNode(int equipletID, int moduleID): rosMast::StateMachine(equipletID, moduleID)
 {
@@ -21,11 +19,18 @@ GripperTestNode::~GripperTestNode()
 	delete gripper;
 }
 
+/** 
+ * A wrapper for the gripper error handler so that we can use a member function
+ * @param Pointer to the gripperTestNode object
+ **/
 void GripperTestNode::WrapperForGripperError(void* gripperNodeObject) {
 	GripperTestNode* myself = (GripperTestNode*) gripperNodeObject;
 	myself->error();
 }
 
+/** 
+ * Sends error message to equipletNode with an errorcode
+ **/
 void GripperTestNode::error(){
 	sendErrorMessage(-1);
 }
@@ -36,15 +41,14 @@ void GripperTestNode::error(){
  **/
 int GripperTestNode::transitionSetup() {
 	ROS_INFO("Setup transition called");
-	setState(rosMast::setup);
-   
+	
+	setState(rosMast::setup); 
 	return 0; 
 }
 
 /**
  * Transition from Standby to Safe state
- * Will turn power off the motor 
- * @return will be 0 if everything went ok else error
+ * @return 0 if everything went OK else error
  **/
 int GripperTestNode::transitionShutdown() {	
 	ROS_INFO("Shutdown transition called");	
@@ -55,7 +59,7 @@ int GripperTestNode::transitionShutdown() {
 
 /**
  * Transition from Standby to Normal state
- * @return will be 0 if everything went ok else error 
+ * @return 0 if everything went OK else error
  **/
 int GripperTestNode::transitionStart() {
 	ROS_INFO("Start transition called");   
@@ -66,7 +70,7 @@ int GripperTestNode::transitionStart() {
 }
 /**
  * Transition from Normal to Standby state
- * @return will be 0 if everything went ok else error
+ * @return 0 if everything went OK else error
  **/
 int GripperTestNode::transitionStop() {
 	ROS_INFO("Stop transition called");
@@ -119,6 +123,6 @@ int main(int argc, char** argv){
 
 	GripperTestNode gripperTestNode(equipletID, moduleID);    
 
-	gripperTestNode.StateEngine();
+	gripperTestNode.startStateMachine();
 	return 0;
 }

--- a/tools/gripperTestNode/src/GripperTestNode.cpp
+++ b/tools/gripperTestNode/src/GripperTestNode.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv){
 	ros::init(argc, argv, NODE_NAME);
 	int equipletID = 0;
 	int moduleID = 0;
-	if(argc != 2 || (Utilities::str2int(equipletID, argv[1]) != 0 && Utilities::str2int(moduleID, argv[2]) != 0))
+	if(argc != 2 || (Utilities::stringToInt(equipletID, argv[1]) != 0 && Utilities::stringToInt(moduleID, argv[2]) != 0))
 	{ 	 	
     	std::cerr << "Cannot read equiplet id and/or moduleId from commandline please use correct values." <<std::endl;
  		return 0;

--- a/tools/gripperTestNode/src/GripperTestNode.cpp
+++ b/tools/gripperTestNode/src/GripperTestNode.cpp
@@ -1,4 +1,5 @@
 #include "GripperTestNode.h"
+#include <Utilities/Utilities.h>
 
 #define NODE_NAME "GripperTestNode"
 
@@ -80,6 +81,14 @@ int GripperTestNode::transitionStop() {
 	return 0;
 }
 
+/**
+ * Set gripper on
+ *
+ * @param req The request for this service as defined in Grip.srv 
+ * @param res The response for this service as defined in Grip.srv
+ *
+ * @return true if gripper is put on else return false.
+ **/
 bool GripperTestNode::grip(gripperTestNode::Grip::Request &req, gripperTestNode::Grip::Response &res)
 {
 	res.succeeded = false;
@@ -95,6 +104,14 @@ bool GripperTestNode::grip(gripperTestNode::Grip::Request &req, gripperTestNode:
 	return true;
 }	
 
+/**
+ * Set gripper off
+ *
+ * @param req The request for this service as defined in Grip.srv 
+ * @param res The response for this service as defined in Grip.srv
+ *
+* @return true if gripper is put off else return false.
+ **/
 bool GripperTestNode::release(gripperTestNode::Release::Request &req, gripperTestNode::Release::Response &res)
 {
 	res.succeeded = false;
@@ -117,9 +134,14 @@ bool GripperTestNode::release(gripperTestNode::Release::Request &req, gripperTes
 int main(int argc, char** argv){
 	
 	ros::init(argc, argv, NODE_NAME);
-
-	int equipletID = atoi(argv[1]);
-	int moduleID = atoi(argv[2]);
+	int equipletID = 0;
+	int moduleID = 0;
+	if(argc != 2 || (Utilities::str2int(equipletID, argv[1]) != 0 && Utilities::str2int(moduleID, argv[2]) != 0))
+	{ 	 	
+    	std::cerr << "Cannot read equiplet id and/or moduleId from commandline please use correct values." <<std::endl;
+ 		return 0;
+  	} 
+	
 
 	GripperTestNode gripperTestNode(equipletID, moduleID);    
 


### PR DESCRIPTION
The equipletnode contains a equipletNode that is used to start new nodes for hardware modules and change their state. There is a StateMachine super class that should be implemented by every hardware module. As an example of how to do this there is a refactored DeltaRobotNode that is a class now and implements a stateMachine. 
