### PR TITLE
Acceleration fix

### DIFF
--- a/libraries/dataTypes/include/DataTypes/MotorRotation.h
+++ b/libraries/dataTypes/include/DataTypes/MotorRotation.h
@@ -69,10 +69,10 @@ namespace DataTypes{
         /**
          * Instantiation of rotation data for the motor.
          *
-         * @param angle The angle in radians the motor has to travel towards
-         * @param speed The speed in radians per second
-         * @param acceleration The acceleration in radians per second per second
-         * @param deceleration The deceleration in radians per second per second
+         * @param angle The angle in radians the motor has to travel towards. Defaults to 0.
+         * @param speed The speed in radians per second. Defaults to 1.
+         * @param acceleration The acceleration in radians per second per second. Defaults to 10.
+         * @param deceleration The deceleration in radians per second per second. Defaults to 10.
          **/
         MotorRotation(double angle = 0, double speed = 1, double acceleration = 10, double deceleration = 10) : angle(angle), speed(speed), acceleration(acceleration), deceleration(deceleration){}
     };

--- a/libraries/dataTypes/include/DataTypes/MotorRotation.h
+++ b/libraries/dataTypes/include/DataTypes/MotorRotation.h
@@ -32,54 +32,48 @@
 #pragma once
 
 namespace DataTypes{
-    template<typename T>
     
     /**
-     * Template class for rotation data for the motor.
+     * Data entity for rotation data for the motor.
      **/
     class MotorRotation{
     public:
         /**
-         * @var T angle
+         * @var double angle
          * The angle in radians the motor has to travel towards
          **/
-        T angle;
+        double angle;
 
         /**
-         * @var T speed
-         * The speed in degrees per second
+         * @var double speed
+         * The speed in radians per second.
          **/
-        T speed;
+        double speed;
 
         /**
-         * @var T acceleration
-         * The acceleration in steps per second
+         * @var double acceleration
+         * The acceleration in radians per second per second.\n 
+         * Minimum: 1 microstep per second == 0.001246637061 rad\n
+         * Maximum: 1000000 microsteps per second = 1256.637061 rad
          **/
-        T acceleration;
+        double acceleration;
 
         /**
-         * @var T deceleration
-         * The deceleration in steps per second
+         * @var double deceleration
+         * The deceleration in radians per second per second.\n 
+         * Minimum: 1 microstep per second == 0.001246637061 rad\n
+         * Maximum: 1000000 microsteps per second = 1256.637061 rad
          **/
-        T deceleration;
-        
-        /**
-         * Instantiation of rotation data for the motor, sets speed, acceleration and deceleration to default values
-         **/
-        MotorRotation(){
-            speed = 10;
-            acceleration = 360;
-            deceleration = 360;
-        }
+        double deceleration;
         
         /**
          * Instantiation of rotation data for the motor.
          *
          * @param angle The angle in radians the motor has to travel towards
-         * @param speed The speed in degrees per second
-         * @param acceleration The acceleration in steps per second
-         * @param deceleration The deceleration in steps per second
+         * @param speed The speed in radians per second
+         * @param acceleration The acceleration in radians per second per second
+         * @param deceleration The deceleration in radians per second per second
          **/
-        MotorRotation(T angle, T speed, T acceleration, T deceleration) : angle(angle), speed(speed), acceleration(acceleration), deceleration(deceleration){}
+        MotorRotation(double angle = 0, double speed = 0.1, double acceleration = 0.1, double deceleration = 0.1) : angle(angle), speed(speed), acceleration(acceleration), deceleration(deceleration){}
     };
 }

--- a/libraries/dataTypes/include/DataTypes/MotorRotation.h
+++ b/libraries/dataTypes/include/DataTypes/MotorRotation.h
@@ -53,16 +53,16 @@ namespace DataTypes{
         /**
          * @var double acceleration
          * The acceleration in radians per second per second.\n 
-         * Minimum: 1 microstep per second == 0.001246637061 rad\n
-         * Maximum: 1000000 microsteps per second = 1256.637061 rad
+         * Minimum: 1.256637061 rad\n
+         * Maximum: 1256637.061 rad
          **/
         double acceleration;
 
         /**
          * @var double deceleration
          * The deceleration in radians per second per second.\n 
-         * Minimum: 1 microstep per second == 0.001246637061 rad\n
-         * Maximum: 1000000 microsteps per second = 1256.637061 rad
+         * Minimum: 1.256637061 rad\n
+         * Maximum: 1256637.061 rad
          **/
         double deceleration;
         
@@ -74,6 +74,6 @@ namespace DataTypes{
          * @param acceleration The acceleration in radians per second per second
          * @param deceleration The deceleration in radians per second per second
          **/
-        MotorRotation(double angle = 0, double speed = 0.1, double acceleration = 0.1, double deceleration = 0.1) : angle(angle), speed(speed), acceleration(acceleration), deceleration(deceleration){}
+        MotorRotation(double angle = 0, double speed = 1, double acceleration = 10, double deceleration = 10) : angle(angle), speed(speed), acceleration(acceleration), deceleration(deceleration){}
     };
 }

--- a/libraries/deltaRobot/include/DeltaRobot/InverseKinematics.h
+++ b/libraries/deltaRobot/include/DeltaRobot/InverseKinematics.h
@@ -65,6 +65,6 @@ namespace DeltaRobot{
 		virtual ~InverseKinematics(void);
 		
 		void destinationPointToMotorRotations(const DataTypes::Point3D<double>& destinationPoint,
-				DataTypes::MotorRotation<double>* (&rotations)[3]) const;
+				DataTypes::MotorRotation* (&rotations)[3]) const;
 	};
 }

--- a/libraries/deltaRobot/include/DeltaRobot/InverseKinematicsModel.h
+++ b/libraries/deltaRobot/include/DeltaRobot/InverseKinematicsModel.h
@@ -107,6 +107,6 @@ namespace DeltaRobot{
 		 * @param rotations Array of MotorRotation objects, will be adjusted by the function to the correct rotations per motor.
 		 **/
 		virtual void destinationPointToMotorRotations(const DataTypes::Point3D<double>& destinationPoint,
-				DataTypes::MotorRotation<double>* (&rotations)[3]) const = 0;
+				DataTypes::MotorRotation* (&rotations)[3]) const = 0;
 	};
 }

--- a/libraries/deltaRobot/src/DeltaRobot.cpp
+++ b/libraries/deltaRobot/src/DeltaRobot.cpp
@@ -209,9 +209,6 @@ namespace DeltaRobot{
         
         // Starting point of calibration
         DataTypes::MotorRotation motorRotation;
-        motorRotation.speed = 1;
-        motorRotation.acceleration = 360;
-        motorRotation.deceleration = 360;
         motorRotation.angle = 0;
 
         // Move motor upwards till the calibration sensor is pushed

--- a/libraries/deltaRobot/src/DeltaRobot.cpp
+++ b/libraries/deltaRobot/src/DeltaRobot.cpp
@@ -128,10 +128,10 @@ namespace DeltaRobot{
             throw Motor::MotorException("motor drivers are not powered on");
         }
 
-        DataTypes::MotorRotation<double>* rotations[3];
-        rotations[0] = new DataTypes::MotorRotation<double>();
-        rotations[1] = new DataTypes::MotorRotation<double>();
-        rotations[2] = new DataTypes::MotorRotation<double>();
+        DataTypes::MotorRotation* rotations[3];
+        rotations[0] = new DataTypes::MotorRotation();
+        rotations[1] = new DataTypes::MotorRotation();
+        rotations[2] = new DataTypes::MotorRotation();
 
         rotations[0]->speed = speed;
         rotations[1]->speed = speed;
@@ -208,7 +208,7 @@ namespace DeltaRobot{
         std::cout << "[DEBUG] Calibrating motor number " << motorIndex << std::endl;
         
         // Starting point of calibration
-        DataTypes::MotorRotation<double> motorRotation;
+        DataTypes::MotorRotation motorRotation;
         motorRotation.speed = 1;
         motorRotation.acceleration = 360;
         motorRotation.deceleration = 360;
@@ -264,7 +264,7 @@ namespace DeltaRobot{
         }
 
         // Return to base! Remove the deviation, we have to find the controller 0 point.
-        DataTypes::MotorRotation<double> motorRotation;
+        DataTypes::MotorRotation motorRotation;
         motorRotation.speed = 0.1;
         motorRotation.angle = 0;
 

--- a/libraries/deltaRobot/src/EffectorBoundaries.cpp
+++ b/libraries/deltaRobot/src/EffectorBoundaries.cpp
@@ -173,10 +173,10 @@ namespace DeltaRobot{
     	}
 
     	if(*fromCache == UNKNOWN){
-    		DataTypes::MotorRotation<double>* rotations[3];
-    		rotations[0] = new DataTypes::MotorRotation<double>();
-    		rotations[1] = new DataTypes::MotorRotation<double>();
-    		rotations[2] = new DataTypes::MotorRotation<double>();
+    		DataTypes::MotorRotation* rotations[3];
+    		rotations[0] = new DataTypes::MotorRotation();
+    		rotations[1] = new DataTypes::MotorRotation();
+    		rotations[2] = new DataTypes::MotorRotation();
 
 			try{
 				kinematics.destinationPointToMotorRotations(fromBitmapCoordinate(coordinate), rotations);

--- a/libraries/deltaRobot/src/InverseKinematics.cpp
+++ b/libraries/deltaRobot/src/InverseKinematics.cpp
@@ -140,7 +140,7 @@ namespace DeltaRobot {
 	 * @param destinationPoint The destination point.
 	 * @param rotations Array of MotorRotation objects, will be adjusted by the function to the correct rotations per motor.
 	 **/
-	void InverseKinematics::destinationPointToMotorRotations(const DataTypes::Point3D<double>& destinationPoint, DataTypes::MotorRotation<double>* (&rotations)[3]) const{
+	void InverseKinematics::destinationPointToMotorRotations(const DataTypes::Point3D<double>& destinationPoint, DataTypes::MotorRotation* (&rotations)[3]) const{
 		// Adding 180 degrees switches 0 degrees for the motor from the midpoint of the engines to directly opposite.
 		// When determining motorAngle the degrees determine the position of the engines:
 		// 	  0 degrees: the hip from this motor moves on the yz plane
@@ -149,8 +149,5 @@ namespace DeltaRobot {
 		rotations[0]->angle = Utilities::degreesToRadians(180) + motorAngle(destinationPoint, Utilities::degreesToRadians(1 * 120));
 		rotations[1]->angle = Utilities::degreesToRadians(180) + motorAngle(destinationPoint, Utilities::degreesToRadians(0 * 120));
 		rotations[2]->angle = Utilities::degreesToRadians(180) + motorAngle(destinationPoint, Utilities::degreesToRadians(2 * 120));
-
-		rotations[0]->acceleration = rotations[1]->acceleration = rotations[2]->acceleration = Utilities::degreesToRadians(3600);
-		rotations[0]->deceleration = rotations[1]->deceleration = rotations[2]->deceleration = Utilities::degreesToRadians(3600);
 	}
 }

--- a/libraries/motor/include/Motor/CRD514KD.h
+++ b/libraries/motor/include/Motor/CRD514KD.h
@@ -50,6 +50,18 @@ namespace Motor{
          **/
         const double MOTOR_FULL_STEP_IN_DEGREES = 1.8;
 
+        /**
+         * @var double MOTOR_MIN_ACCELERATION
+         * The minimum acceleration in radians per second per second. This same value counts for the minimum deceleration.
+         **/
+        const double MOTOR_MIN_ACCELERATION = 1.256637061;
+
+        /**
+         * @var double MOTOR_MAX_ACCELERATION
+         * The maximum acceleration in radians per second per second. This same value counts for the maximum deceleration.
+         **/
+        const double MOTOR_MAX_ACCELERATION = 1256637.061;        
+
         namespace Slaves{
             /**
              * CRD514KD slave addresses.

--- a/libraries/motor/include/Motor/MotorInterface.h
+++ b/libraries/motor/include/Motor/MotorInterface.h
@@ -71,7 +71,7 @@ namespace Motor{
 		 * 
 		 * @param motorRotation Defines the angles, speed, acceleration and deceleration of the motors.
 		 **/
-	 	virtual void moveTo(const DataTypes::MotorRotation<double>& motorRotation) = 0;
+	 	virtual void moveTo(const DataTypes::MotorRotation& motorRotation) = 0;
 
 	 	/**
 		 * Rotates the motors within a certain time. The speed member of the given motion is ignored.
@@ -80,7 +80,7 @@ namespace Motor{
 		 * @param time Time in seconds that the motors will take to rotate to the given angles. 
 		 * @param start The movement will start immediately if true.
 		 **/
-		virtual void moveToWithin(const DataTypes::MotorRotation<double>& motorRotation, double time, bool start) = 0;
+		virtual void moveToWithin(const DataTypes::MotorRotation& motorRotation, double time, bool start) = 0;
 
 		/**
 		 * Wait till the motor has finished any rotations.

--- a/libraries/motor/include/Motor/StepperMotor.h
+++ b/libraries/motor/include/Motor/StepperMotor.h
@@ -58,7 +58,7 @@ namespace Motor{
         void setMotorLimits(double minAngle, double maxAngle);
 
         void moveTo(const DataTypes::MotorRotation& motorRotation);
-        void writeRotationData(const DataTypes::MotorRotation& motorRotation);
+        void writeRotationData(const DataTypes::MotorRotation& motorRotation, bool useDeviation = true);
 
         void startMovement(void);
         void moveToWithin(const DataTypes::MotorRotation& motorRotation, double time, bool start);

--- a/libraries/motor/include/Motor/StepperMotor.h
+++ b/libraries/motor/include/Motor/StepperMotor.h
@@ -57,11 +57,11 @@ namespace Motor{
         void resetCounter(void);
         void setMotorLimits(double minAngle, double maxAngle);
 
-        void moveTo(const DataTypes::MotorRotation<double>& motorRotation);
-        void writeRotationData(const DataTypes::MotorRotation<double>& motorRotation);
+        void moveTo(const DataTypes::MotorRotation& motorRotation);
+        void writeRotationData(const DataTypes::MotorRotation& motorRotation);
 
         void startMovement(void);
-        void moveToWithin(const DataTypes::MotorRotation<double>& motorRotation, double time, bool start);
+        void moveToWithin(const DataTypes::MotorRotation& motorRotation, double time, bool start);
         void waitTillReady(void);
 
         bool isPoweredOn(void){ return poweredOn; }

--- a/libraries/motor/src/StepperMotor.cpp
+++ b/libraries/motor/src/StepperMotor.cpp
@@ -185,14 +185,16 @@ namespace Motor{
 
 		uint32_t motorSpeed = (uint32_t)(motorRotation.speed / CRD514KD::MOTOR_STEP_ANGLE);
 		
-		// Formula to turn rad/s² into ms/kHz
-		// First 1000 is for amount of milliseconds in a second
-		// Second 1000 is for amount of steps/s in a kHz
-		uint32_t motorAcceleration = (uint32_t)((1000/(motorRotation.acceleration/(CRD514KD::MOTOR_STEP_ANGLE * 1000))));
-		uint32_t motorDeceleration = (uint32_t)((1000/(motorRotation.deceleration/(CRD514KD::MOTOR_STEP_ANGLE * 1000))));
+		// Formula to turn rad/s² into µs/kHz
+		// 1000000 is for amount of microseconds in a second
+		// 1000 is for amount of steps/s in a kHz
+		uint32_t motorAcceleration = (uint32_t)((1000000/(motorRotation.acceleration/(CRD514KD::MOTOR_STEP_ANGLE * 1000))));
+		uint32_t motorDeceleration = (uint32_t)((1000000/(motorRotation.deceleration/(CRD514KD::MOTOR_STEP_ANGLE * 1000))));
 
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_SPEED, motorSpeed, true);
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_POS, motorSteps, true);
+
+		std::cout << "Writing acceleration " << motorRotation.acceleration << " -> " << motorAcceleration << std::endl;
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_ACC, motorAcceleration, true);
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_DEC, motorDeceleration, true);
 		setAngle = motorRotation.angle;

--- a/libraries/motor/src/StepperMotor.cpp
+++ b/libraries/motor/src/StepperMotor.cpp
@@ -158,7 +158,7 @@ namespace Motor{
 	 *
 	 * @param motorRotation The rotational data for the motor.
 	 **/
-	void StepperMotor::moveTo(const DataTypes::MotorRotation<double>& motorRotation){
+	void StepperMotor::moveTo(const DataTypes::MotorRotation& motorRotation){
 		writeRotationData(motorRotation);
 		startMovement();
 	}
@@ -168,7 +168,7 @@ namespace Motor{
 	 * 
 	 * @param motorRotation A MotorRotation.
 	 **/
-	void StepperMotor::writeRotationData(const DataTypes::MotorRotation<double>& motorRotation){
+	void StepperMotor::writeRotationData(const DataTypes::MotorRotation& motorRotation){
 		if(!poweredOn){
 			throw MotorException("motor drivers are not powered on");
 		}
@@ -215,8 +215,8 @@ namespace Motor{
 	 * @param time Time in seconds that the motors will take to rotate to the given angle. Speed member of given motion is ignored.
 	 * @param start If the movement should start immediately.
 	 **/
-	void StepperMotor::moveToWithin(const DataTypes::MotorRotation<double>& motorRotation, double time, bool start){
-		DataTypes::MotorRotation<double> newMotorRotation = motorRotation;
+	void StepperMotor::moveToWithin(const DataTypes::MotorRotation& motorRotation, double time, bool start){
+		DataTypes::MotorRotation newMotorRotation = motorRotation;
 		newMotorRotation.speed = fabs(currentAngle - motorRotation.angle) / time;
 		if(start){
 			moveTo(newMotorRotation);

--- a/libraries/motor/src/StepperMotor.cpp
+++ b/libraries/motor/src/StepperMotor.cpp
@@ -199,7 +199,7 @@ namespace Motor{
 	}
 
 	/**
-	 * Start the motor to move according to the set registers.
+	 * Start the motor to move according to the set registers. Will wait for the motor to be ready before moving.
 	 **/
 	void StepperMotor::startMovement(void){
 		if(!poweredOn){

--- a/libraries/motor/src/StepperMotor.cpp
+++ b/libraries/motor/src/StepperMotor.cpp
@@ -178,6 +178,13 @@ namespace Motor{
 			throw std::out_of_range("one or more angles out of range");
 		}
 
+		if(motorRotation.acceleration > CRD514KD::MOTOR_MAX_ACCELERATION 
+			|| motorRotation.acceleration < CRD514KD::MOTOR_MIN_ACCELERATION
+			|| motorRotation.deceleration > CRD514KD::MOTOR_MAX_ACCELERATION
+			|| motorRotation.deceleration < CRD514KD::MOTOR_MIN_ACCELERATION){
+			throw std::out_of_range("Acceleration or deceleration out of range.");
+		}
+
 		uint32_t motorSteps = (uint32_t)(motorRotation.angle / CRD514KD::MOTOR_STEP_ANGLE);
 		if(useDeviation) {
 			motorSteps += (uint32_t)(deviation / CRD514KD::MOTOR_STEP_ANGLE);
@@ -193,8 +200,6 @@ namespace Motor{
 
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_SPEED, motorSpeed, true);
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_POS, motorSteps, true);
-
-		std::cout << "Writing acceleration " << motorRotation.acceleration << " -> " << motorAcceleration << std::endl;
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_ACC, motorAcceleration, true);
 		modbus->writeU32(motorIndex, CRD514KD::Registers::OP_DEC, motorDeceleration, true);
 		setAngle = motorRotation.angle;


### PR DESCRIPTION
New way of dealing with acceleration, allowing use of rad/s². MotorRotation is now no longer a template class, it is now full of doubles. Also edited some comments here and there. Also added another parameter to StepperMotor's WriteRotationData that allows us to choose whether or not to use deviation. This parameter defaults to true, so it should not affect anything old.
