### PR TITLE
deltaRobotLibraryFixes

### DIFF
--- a/libraries/deltaRobot/include/DeltaRobot/EffectorBoundaries.h
+++ b/libraries/deltaRobot/include/DeltaRobot/EffectorBoundaries.h
@@ -48,49 +48,13 @@ namespace DeltaRobot{
 	class EffectorBoundaries{
 	public:
 		~EffectorBoundaries();
-
-		// TODO: change Motor::StepperMotor to two doubles for max and min angle
-		static EffectorBoundaries* generateEffectorBoundaries(const InverseKinematicsModel& model, Motor::StepperMotor* (&motors)[3], double voxelSize);
+		
+		static EffectorBoundaries* generateEffectorBoundaries(const InverseKinematicsModel& model, double motorMinAngles[3], double motorMaxAngles[3], double voxelSize);
 
 		bool checkPath(const DataTypes::Point3D<double>& from, const DataTypes::Point3D<double>& to) const;
 
-		/**
-		 * Gets the boundariesBitmap. This bitmap is a one dimensional array of booleans, defaulted to false, where voxels are checked and set to true if they are reachable.
-		 *
-		 * @return A const bool pointer to the voxel bitmap. This bitmap is a one dimensional array of booleans, defaulted to false, where voxels are checked and set to true if they are reachable.
-		 **/
-		inline const bool* getBitmap() const{ return boundariesBitmap; }
-
-		/**
-		 * Gets the depth used to make the boundaries bitmap.
-		 *
-		 * @return The depth in voxels.
-		 **/
-		inline int getDepth() const{ return depth; }
-
-		/**
-		 * Gets the height used to make the boundaries bitmap.
-		 *
-		 * @return The height in voxels.
-		 **/
-		inline int getHeight() const{ return height; }
-
-		/**
-		 * Gets the width used to make the boundaries bitmap.
-		 *
-		 * @return The width in voxels.
-		 **/
-		inline int getWidth() const{ return width; }
-
-		/**
-		 * Gets the size of a side of a voxel.
-		 *
-		 * @return Voxel size in millimeters.
-		 **/
-		inline double getVoxelSize() const{ return voxelSize; }
-
 	private:
-		EffectorBoundaries(const InverseKinematicsModel& model, Motor::StepperMotor* (&motors)[3], double voxelSize);
+		EffectorBoundaries(const InverseKinematicsModel& model, double motorMinAngles[3], double motormaxAngles[3], double voxelSize);
 
 		/**
 		 * Represents a 3-dimensional point in the 3D voxel array.
@@ -192,10 +156,16 @@ namespace DeltaRobot{
 		const InverseKinematicsModel &kinematics;
 
 		/**
-		 * @var StepperMotor* motors
-		 * An array holding pointers to the three StepperMotors that are connected to the DeltaRobot. This array HAS to be of size 3. The EffectorBoundaries needs to know the motors to find out their max and min angles.
+		 * @var double motorMinAngles 
+		 * Holds the minimum angles of the motors.
 		 **/
-		Motor::StepperMotor* (&motors)[3];
+		double motorMinAngles[3];
+
+		/**
+		 * @var double motorMaxAngles 
+		 * Holds the maximum angles of the motors.
+		 **/
+		double motorMaxAngles[3];
 
 		/**
 		 * @var double voxelSize

--- a/libraries/deltaRobot/src/DeltaRobot.cpp
+++ b/libraries/deltaRobot/src/DeltaRobot.cpp
@@ -91,7 +91,9 @@ namespace DeltaRobot{
      * @param voxelSize The size in millimeters of a side of a voxel in the boundaries.
      **/
     void DeltaRobot::generateBoundaries(double voxelSize){
-        boundaries = EffectorBoundaries::generateEffectorBoundaries((*kinematics), motors, voxelSize);
+        double motorMinAngles[3] = {Measures::MOTOR_ROT_MIN, Measures::MOTOR_ROT_MIN, Measures::MOTOR_ROT_MIN};
+        double motorMaxAngles[3] = {Measures::MOTOR_ROT_MAX, Measures::MOTOR_ROT_MAX, Measures::MOTOR_ROT_MAX};
+        boundaries = EffectorBoundaries::generateEffectorBoundaries((*kinematics), motorMinAngles, motorMaxAngles, voxelSize);
         boundariesGenerated = true;
     }
 
@@ -368,7 +370,7 @@ namespace DeltaRobot{
 
         // calculate and set the deviation.
         double deviation = (actualAngleInSteps * Motor::CRD514KD::MOTOR_STEP_ANGLE) + Measures::MOTORS_FROM_ZERO_TO_TOP_POSITION;
-        motors[motorIndex]->setDeviation(deviation);
+        motors[motorIndex]->setDeviationAndWriteMotorLimits(deviation);
         
         // Move back to the new 0.
         motors[motorIndex]->setAbsoluteMode(1);
@@ -412,9 +414,9 @@ namespace DeltaRobot{
         motorRotation.speed = 0.1;
         motorRotation.angle = 0;
 
-        motors[0]->setDeviation(0);
-        motors[1]->setDeviation(0);
-        motors[2]->setDeviation(0);
+        motors[0]->setDeviationAndWriteMotorLimits(0);
+        motors[1]->setDeviationAndWriteMotorLimits(0);
+        motors[2]->setDeviationAndWriteMotorLimits(0);
 
         motors[0]->writeRotationData(motorRotation, 1);
         motors[1]->writeRotationData(motorRotation, 1);
@@ -435,10 +437,10 @@ namespace DeltaRobot{
         calibrateMotor(1);
         calibrateMotor(2);
 
-        // Set limitations
-        motors[0]->setMotorLimits(Measures::MOTOR_ROT_MIN, Measures::MOTOR_ROT_MAX);
-        motors[1]->setMotorLimits(Measures::MOTOR_ROT_MIN, Measures::MOTOR_ROT_MAX);
-        motors[2]->setMotorLimits(Measures::MOTOR_ROT_MIN, Measures::MOTOR_ROT_MAX);
+        // Enable angle limitations
+        motors[0]->enableAngleLimitations();
+        motors[1]->enableAngleLimitations();
+        motors[2]->enableAngleLimitations();
 
         effectorLocation.x = 0;
         effectorLocation.y = 0;

--- a/libraries/deltaRobot/src/EffectorBoundaries.cpp
+++ b/libraries/deltaRobot/src/EffectorBoundaries.cpp
@@ -45,13 +45,14 @@ namespace DeltaRobot{
 	 * Function to generate the boundaries and returns a pointer to the object.
 	 * 
 	 * @param model Used to calculate the boundaries.
-	 * @param motors Used for the minimum and maximum angle of the motors.
+	 * @param motorMinAngles An array holding the minimum angle of each of the three motors.
+	 * @param motorMaxAngles An array holding the maximum angle of each of the three motors.
 	 * @param voxelSize The size of the voxels in millimeters.
 	 * 
 	 * @return Pointer to the object.
 	 **/
-	EffectorBoundaries* EffectorBoundaries::generateEffectorBoundaries(const InverseKinematicsModel& model, Motor::StepperMotor* (&motors)[3], double voxelSize){
-		EffectorBoundaries* boundaries = new EffectorBoundaries(model, motors, voxelSize);
+	EffectorBoundaries* EffectorBoundaries::generateEffectorBoundaries(const InverseKinematicsModel& model, double motorMinAngles[3], double motorMaxAngles[3], double voxelSize){
+		EffectorBoundaries* boundaries = new EffectorBoundaries(model, motorMinAngles, motorMaxAngles, voxelSize);
 		
 		// Create boundaries variables in voxel space by dividing real space variables with the voxel size
 		boundaries->width = (Measures::BOUNDARY_BOX_MAX_X  - Measures::BOUNDARY_BOX_MIN_X) / voxelSize;
@@ -112,17 +113,22 @@ namespace DeltaRobot{
 	 * Private constructor, it also initializes the voxel array.
 	 * 
 	 * @param model Used to calculate the boundaries.
-	 * @param motors Used for the minimum and maximum angle of the motors.
+	 * @param motorMinAngles An array holding the minimum angle of each of the three motors.
+	 * @param motorMaxAngles An array holding the maximum angle of each of the three motors.
 	 * @param voxelSize The size of the voxels.
 	 **/
-    EffectorBoundaries::EffectorBoundaries(const InverseKinematicsModel& model,  Motor::StepperMotor* (&motors)[3], double voxelSize) : 
+    EffectorBoundaries::EffectorBoundaries(const InverseKinematicsModel& model, double motorMinAngles[3], double motorMaxAngles[3], double voxelSize) : 
     	width(0), 
     	height(0), 
     	depth(0), 
     	boundariesBitmap(NULL), 
-    	kinematics(model), 
-    	motors(motors), 
-    	voxelSize(voxelSize) {}
+    	kinematics(model),  
+    	voxelSize(voxelSize) {
+    		for(int i = 0; i < 3; i++){
+    			this->motorMinAngles[i] = motorMinAngles[i];
+    			this->motorMaxAngles[i] = motorMaxAngles[i];
+    		}
+    	}
 
     EffectorBoundaries::~EffectorBoundaries(){
     	delete[] boundariesBitmap;
@@ -195,9 +201,9 @@ namespace DeltaRobot{
 			}
 
 			// Check motor angles.
-			if(rotations[0]->angle <= motors[0]->getMinAngle() || rotations[0]->angle >= motors[0]->getMaxAngle() ||
-			  rotations[1]->angle <= motors[1]->getMinAngle() || rotations[1]->angle >= motors[1]->getMaxAngle()  ||
-			  rotations[2]->angle <= motors[2]->getMinAngle() || rotations[2]->angle >= motors[2]->getMaxAngle()  ){
+			if(rotations[0]->angle <= motorMinAngles[0] || rotations[0]->angle >= motorMaxAngles[0] 
+			|| rotations[1]->angle <= motorMinAngles[1] || rotations[1]->angle >= motorMaxAngles[1] 
+			|| rotations[2]->angle <= motorMinAngles[2] || rotations[2]->angle >= motorMaxAngles[2]){
 			  	*fromCache = INVALID;
 				delete rotations[0];
 				delete rotations[1];

--- a/libraries/motor/include/Motor/MotorInterface.h
+++ b/libraries/motor/include/Motor/MotorInterface.h
@@ -61,11 +61,6 @@ namespace Motor{
 		virtual void stop(void) = 0;
 
 		/**
-		 * Sets the minimum and maximum angle for the motor.
-		 **/
-		virtual void setMotorLimits(double minAngle, double maxAngle) = 0;
-
-		/**
 		 * Rotate the motors.
 		 * 
 		 * @param motorRotation Defines the angles, speed, acceleration and deceleration of the motors.

--- a/libraries/motor/include/Motor/StepperMotor.h
+++ b/libraries/motor/include/Motor/StepperMotor.h
@@ -55,7 +55,6 @@ namespace Motor{
 		void stop(void);
 
 		void resetCounter(void);
-		void setMotorLimits(double minAngle, double maxAngle);
 
 		void moveTo(const DataTypes::MotorRotation& motorRotation, int motionSlot);
 		void moveTo(const DataTypes::MotorRotation& motorRotation);
@@ -88,9 +87,6 @@ namespace Motor{
 		 **/
 		inline double getCurrentAngle(void) const{ return currentAngle; }
 
-		void setMinAngle(double minAngle);
-		void setMaxAngle(double maxAngle);
-
 		/**
 		 * Stores the angle that was given to the motor in the local variable currentAngle.
 		 *
@@ -105,13 +101,9 @@ namespace Motor{
 		 **/
 		double getDeviation(void){ return deviation; }
 
-		/**
-		 * Sets the deviation between the motors 0 degrees and the horizontal 0 degrees.
-		 *
-		 * @param deviation The deviation between the hardware and theoretical 0 degrees.
-		 **/
-		void setDeviation(double deviation){ this->deviation = deviation; }
+		void setDeviationAndWriteMotorLimits(double deviation);
 
+		void enableAngleLimitations(void);
 		void disableAngleLimitations(void);
 		void updateAngle(void);
 

--- a/libraries/motor/src/StepperMotor.cpp
+++ b/libraries/motor/src/StepperMotor.cpp
@@ -144,18 +144,6 @@ namespace Motor{
 	}
 
 	/**
-	 * Set the motor limits in the motor hardware.
-	 *
-	 * @param minAngle Minimum for the angle, in radians, the StepperMotor can travel on the theoretical plane.
-	 * @param maxAngle Maximum for the angle, in radians, the StepperMotor can travel on the theoretical plane.
-	 **/
-	void StepperMotor::setMotorLimits(double minAngle, double maxAngle){
-		// Set motors limits.
-		setMinAngle(minAngle);
-		setMaxAngle(maxAngle);
-	}
-
-	/**
 	 * Moves the motor to the given position.
 	 *
 	 * @param motorRotation The rotational data for the motor.
@@ -257,27 +245,14 @@ namespace Motor{
 	}
 
 	/**
-	 * Sets the angle limitations for the minimum the motor can travel in the motor hardware.
+	 * Sets the deviation between the motors 0 degrees and the horizontal 0 degrees, then writes the new motor limits to the motor controllers.
 	 *
-	 * @param minAngle Minimum for the angle, in radians, the StepperMotor can travel on the theoretical plane.
+	 * @param deviation The deviation between the hardware and theoretical 0 degrees.
 	 **/
-	void StepperMotor::setMinAngle(double minAngle){
-		this->minAngle = minAngle;
+	void StepperMotor::setDeviationAndWriteMotorLimits(double deviation){
+		this->deviation = deviation;
 		modbus->writeU32(motorIndex, CRD514KD::Registers::CFG_POSLIMIT_NEGATIVE, (uint32_t)((minAngle + deviation) / CRD514KD::MOTOR_STEP_ANGLE));
-		modbus->writeU16(motorIndex, CRD514KD::Registers::OP_SOFTWARE_OVERTRAVEL, 1);
-		anglesLimited = true;
-	}
-
-	/**
-	 * Sets the angle limitations for the maximum the motor can travel in the motor hardware.
-	 *
-	 * @param maxAngle Maximum for the angle, in radians, the StepperMotor can travel on the theoretical plane.
-	 **/
-	void StepperMotor::setMaxAngle(double maxAngle){
-		this->maxAngle = maxAngle;
 		modbus->writeU32(motorIndex, CRD514KD::Registers::CFG_POSLIMIT_POSITIVE, (uint32_t)((maxAngle + deviation) / CRD514KD::MOTOR_STEP_ANGLE));
-		modbus->writeU16(motorIndex, CRD514KD::Registers::OP_SOFTWARE_OVERTRAVEL, 1);
-		anglesLimited = true;
 	}
 
 	/**
@@ -286,6 +261,14 @@ namespace Motor{
 	void StepperMotor::disableAngleLimitations(void){
 		modbus->writeU16(motorIndex, CRD514KD::Registers::OP_SOFTWARE_OVERTRAVEL, 0);
 		anglesLimited = false;
+	}
+
+	/**
+	 * Enables the limitations on the angles the motor can travel to in the motor hardware.
+	 **/
+	void StepperMotor::enableAngleLimitations(void){
+		modbus->writeU16(motorIndex, CRD514KD::Registers::OP_SOFTWARE_OVERTRAVEL, 1);
+		anglesLimited = true;	
 	}
 
 	/**


### PR DESCRIPTION
Changed up the way the Steppermotors' deviation and min/max angles are set. Min/max angles are now set on construction never to be changed. Deviation is set with a function that also writes the new min/max angles (offset by the new deviation) to the motor controllers.

EffectorBoundaries no longer knows the StepperMotors now, it just knows their min/max angles, these angles can no longer change after construction.

Removed some getter methods from EffectorBoundaries that were unused.
