### PR TITLE
Changed some things in Cmake because crate_locator_node no longer compiled.

### DIFF
--- a/src/cmake/ExternalLibraries.cmake
+++ b/src/cmake/ExternalLibraries.cmake
@@ -55,9 +55,9 @@ find_package(Unicap)
 
 # OpenCV should automatically work because of ROS, but on some Ubuntu configurations
 # it seems necessary to set OpenCV_DIR correctly. The next statement will try to 
-# automatically guess this seting for ROS fuerte. 
+# automatically guess this setting for ROS Groovy. 
 if(NOT OpenCV_DIR)
-	find_path(OpenCV_DIR "OpenCVConfig.cmake" DOC "Root directory of OpenCV" HINTS "/opt/ros/fuerte/share/OpenCV/")
+	find_path(OpenCV_DIR "OpenCVConfig.cmake" DOC "Root directory of OpenCV" HINTS "/opt/ros/groovy/share/OpenCV/")
 endif(NOT OpenCV_DIR)
 # Finally, try finding the package
 find_package(OpenCV)

--- a/src/ros/crate_locator_node/CMakeLists.txt
+++ b/src/ros/crate_locator_node/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 project(crate_locator_node)
 
 ## Find catkin and any catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp std_msgs message_generation image_transport cv_bridge opencv2 sensor_msgs rexos_datatypes rexos_utilities rexos_vision)
+find_package(catkin REQUIRED COMPONENTS roscpp std_msgs message_generation image_transport cv_bridge sensor_msgs rexos_datatypes rexos_utilities rexos_vision)
 find_package(Log4cxx)
+find_package(OpenCV)
 
 file(GLOB_RECURSE msgs RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/msg" "*.msg")
 add_message_files(
@@ -23,8 +24,8 @@ generate_messages (
 catkin_package(
 INCLUDE_DIRS include 
 LIBRARIES  
-CATKIN_DEPENDS roscpp image_transport cv_bridge opencv2 sensor_msgs rexos_datatypes rexos_utilities rexos_vision
-DEPENDS)
+CATKIN_DEPENDS roscpp image_transport cv_bridge sensor_msgs rexos_datatypes rexos_utilities rexos_vision
+DEPENDS OpenCV)
 
 file(GLOB_RECURSE sources "src" "*.cpp" "*.c")
 include_directories(include ${catkin_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIR})


### PR DESCRIPTION
- ExternalLibraries.cmake changed to look for OpenCV in groovy rather than fuerte.
- crate_locator_node's CmakeList changed to no longer include openCV as a Catkin package but as a library. Not properly tested, but at least now it compiles.
