### PR TITLE
Equiplet simulation: Dummy module.

### DIFF
--- a/src/ros/dummy_module_node/CMakeLists.txt
+++ b/src/ros/dummy_module_node/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(dummy_module_node)
+
+## Find catkin and any catkin packages
+find_package(catkin REQUIRED COMPONENTS roscpp std_msgs message_generation rexos_mast rexos_std_msgs rexos_std_srvs Libjson rexos_utilities)
+find_package(Log4cxx)
+
+generate_messages (
+	DEPENDENCIES std_msgs
+)
+
+## Declare a catkin package
+catkin_package(
+INCLUDE_DIRS include 
+LIBRARIES  
+CATKIN_DEPENDS rexos_mast rexos_std_msgs rexos_std_srvs Libjson roscpp std_msgs rexos_utilities
+DEPENDS)
+
+file(GLOB_RECURSE sources "src" "*.cpp" "*.c")
+include_directories(include ${catkin_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIR})
+add_executable(dummy_module_node src/DummyModuleNode.cpp)
+
+target_link_libraries(dummy_module_node ${catkin_LIBRARIES} ${LOG4CXX_LIBRARIES})
+add_dependencies(dummy_module_node dummy_module_node_gencpp)
+

--- a/src/ros/dummy_module_node/include/dummy_module_node/DummyModuleNode.h
+++ b/src/ros/dummy_module_node/include/dummy_module_node/DummyModuleNode.h
@@ -1,0 +1,66 @@
+/**
+ * @file DummyModuleNode.h
+ * @brief A dummy module!
+ * @date Created: 2013-03-13
+ *
+ * @author Arjen van Zanten
+ * @author Ammar Abdulamir
+ *
+ * @section LICENSE
+ * License: newBSD
+ * Copyright © 2013, HU University of Applied Sciences Utrecht.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the HU University of Applied Sciences Utrecht nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE HU UNIVERSITY OF APPLIED SCIENCES UTRECHT
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#ifndef DUMMYMODULENODE_H
+#define DUMMYMODULENODE_H
+
+#include "ros/ros.h"
+#include "rexos_std_srvs/Module.h"
+
+#include <rexos_utilities/Utilities.h>
+#include <rexos_mast/StateMachine.h>
+
+// GCC system header to suppress libjson warnings
+#pragma GCC system_header
+#include <Libjson/libjson.h>
+// ---------------------------------------------
+
+class DummyModuleNode : public rexos_mast::StateMachine{
+public:
+	DummyModuleNode(int equipletID, int moduleID);
+	virtual ~DummyModuleNode();
+	
+	int transitionSetup();
+	int transitionShutdown();
+	int transitionStart();
+	int transitionStop();
+
+	// services
+	bool outputCoords(rexos_std_srvs::Module::Request &req, rexos_std_srvs::Module::Response &res);
+
+private:
+	/**
+	 * @var ros::ServiceServer outputCoords
+	 * Service for outputting coordinates
+	 **/
+	ros::ServiceServer outputCoordsService;
+};
+
+#endif

--- a/src/ros/dummy_module_node/include/dummy_module_node/DummyModuleNode.h
+++ b/src/ros/dummy_module_node/include/dummy_module_node/DummyModuleNode.h
@@ -53,14 +53,20 @@ public:
 	int transitionStop();
 
 	// services
-	bool outputCoords(rexos_std_srvs::Module::Request &req, rexos_std_srvs::Module::Response &res);
+	bool outputJSON(rexos_std_srvs::Module::Request &req, rexos_std_srvs::Module::Response &res);
 
 private:
 	/**
-	 * @var ros::ServiceServer outputCoords
+	 * @var std::string nodeName
+	 * The node's name.
+	 **/
+	 std::string nodeName;
+
+	/**
+	 * @var ros::ServiceServer outputJSON
 	 * Service for outputting coordinates
 	 **/
-	ros::ServiceServer outputCoordsService;
+	ros::ServiceServer outputJSONService;
 };
 
 #endif

--- a/src/ros/dummy_module_node/include/dummy_module_node/Services.h
+++ b/src/ros/dummy_module_node/include/dummy_module_node/Services.h
@@ -35,8 +35,8 @@
 
 namespace DummyModuleNodeServices{
 	/**
-	 * @var const std::string OUTPUTCOORDS
-	 * Name for the service for outputting coordinates
+	 * @var const std::string OUTPUTJSON
+	 * Name base for the service for outputting a json string (unparsed), will be prepended by the node name in the actual advertised service name.
 	 **/
-	const std::string OUTPUTCOORDS = "DummyModuleNode/outputCoords";
+	const std::string OUTPUTJSON = "outputJSON";
 }

--- a/src/ros/dummy_module_node/include/dummy_module_node/Services.h
+++ b/src/ros/dummy_module_node/include/dummy_module_node/Services.h
@@ -1,0 +1,42 @@
+/**
+ * @file Services.h
+ * @brief Dummy module services
+ * @date Created: 2013-03-13
+ *
+ * @author Arjen van Zanten
+ * @author Ammar Abdulamir
+ *
+ * @section LICENSE
+ * License: newBSD
+ *
+ * Copyright © 2013, HU University of Applied Sciences Utrecht.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the HU University of Applied Sciences Utrecht nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE HU UNIVERSITY OF APPLIED SCIENCES UTRECHT
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#pragma once
+
+#include <string>
+
+namespace DummyModuleNodeServices{
+	/**
+	 * @var const std::string OUTPUTCOORDS
+	 * Name for the service for outputting coordinates
+	 **/
+	const std::string OUTPUTCOORDS = "DummyModuleNode/outputCoords";
+}

--- a/src/ros/dummy_module_node/package.xml
+++ b/src/ros/dummy_module_node/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package>
+    <name>dummy_module_node</name>
+    <version>0.0.0</version>
+    <description>The dummy_module_node package</description>
+    <maintainer email="lowcostvision@gmail.com">Leau Caust</maintainer>
+    <license>newBSD</license>
+    <url type="website">https://github.com/AgileManufacturing/HUniversal-Production-Utrecht</url>
+    <author email="ap.vanzanten@gmail.com">Arjen van Zanten</author>
+    <author email="ammar.abdulamir@gmail.com">Ammar Abdulamir</author>
+    <buildtool_depend>catkin</buildtool_depend>
+    <build_depend>std_msgs</build_depend>
+    <build_depend>roscpp</build_depend>
+    <build_depend>rexos_mast</build_depend>
+    <build_depend>rexos_std_msgs</build_depend>
+    <build_depend>rexos_std_srvs</build_depend>
+    <build_depend>rexos_utilities</build_depend>
+    <build_depend>Libjson</build_depend>
+    <run_depend>roscpp</run_depend>
+    <run_depend>std_msgs</run_depend>
+    <run_depend>rexos_mast</run_depend>
+    <run_depend>rexos_std_msgs</run_depend>
+    <run_depend>rexos_std_srvs</run_depend>
+    <run_depend>rexos_utilities</run_depend>
+    <run_depend>Libjson</run_depend>
+    <export>
+        <cpp cflags="-I${prefix}/include"/>
+    </export>
+</package>

--- a/src/ros/dummy_module_node/src/DummyModuleNode.cpp
+++ b/src/ros/dummy_module_node/src/DummyModuleNode.cpp
@@ -31,21 +31,33 @@
  #include "dummy_module_node/DummyModuleNode.h"
  #include "dummy_module_node/Services.h"
 
- // @cond HIDE_NODE_NAME_FROM_DOXYGEN
-#define NODE_NAME "DummyModuleNode"
+ // @cond HIDE_NODE_NAME_BASE_FROM_DOXYGEN
+#define NODE_NAME_BASE "dummy_module_node"
 // @endcond
 
 DummyModuleNode::DummyModuleNode(int equipletID, int moduleID) : rexos_mast::StateMachine(equipletID, moduleID) {
-	std::cout << "Constructing DummyModuleNode. EquipletID: " << equipletID << "ModuleID: " << moduleID << std::endl;
+
+	std::stringstream stringStream;
+	stringStream <<  NODE_NAME_BASE << "_" << equipletID << "_" << moduleID;
+	nodeName = stringStream.str();
+
+	std::cout << "Constructing " << nodeName << std::endl;
 
 	ros::NodeHandle nodeHandle;
 
-	outputCoordsService = nodeHandle.advertiseService(DummyModuleNodeServices::OUTPUTCOORDS, &DummyModuleNode::outputCoords, this);
+	stringStream.clear();
+	stringStream.str("");
+	stringStream << nodeName << "/" << DummyModuleNodeServices::OUTPUTJSON;
+	std::string outputJSONServiceName = stringStream.str();
+
+	outputJSONService = nodeHandle.advertiseService(outputJSONServiceName, &DummyModuleNode::outputJSON, this);
 }
 
-bool DummyModuleNode::outputCoords(rexos_std_srvs::Module::Request &req, rexos_std_srvs::Module::Response &res){
-	ROS_INFO("outputCoords called");
+bool DummyModuleNode::outputJSON(rexos_std_srvs::Module::Request &req, rexos_std_srvs::Module::Response &res){
+	ROS_INFO("outputJSON called");
 	std::cout << std::string(req.json) << std::endl;
+	res.succeeded = true;
+	res.message = "success!";
 	return true;
 }
 
@@ -90,7 +102,10 @@ int main(int argc, char **argv){
 		return -1;
 	}
 
-	ros::init(argc, argv, NODE_NAME);
+	std::stringstream stringStream;
+	stringStream <<  NODE_NAME_BASE << "_" << equipletID << "_" << moduleID;
+	std::string nodeName = stringStream.str();
+	ros::init(argc, argv, nodeName);
 
 	ROS_INFO("Creating Dummy Module");
 

--- a/src/ros/dummy_module_node/src/DummyModuleNode.cpp
+++ b/src/ros/dummy_module_node/src/DummyModuleNode.cpp
@@ -1,0 +1,102 @@
+/**
+ * @file DummyModuleNode.cpp
+ * @brief A dummy module!
+ * @date Created: 2013-03-13
+ *
+ * @author Arjen van Zanten
+ * @author Ammar Abdulamir
+ *
+ * @section LICENSE
+ * License: newBSD
+ * Copyright © 2013, HU University of Applied Sciences Utrecht.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the HU University of Applied Sciences Utrecht nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE HU UNIVERSITY OF APPLIED SCIENCES UTRECHT
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+ #include "dummy_module_node/DummyModuleNode.h"
+ #include "dummy_module_node/Services.h"
+
+ // @cond HIDE_NODE_NAME_FROM_DOXYGEN
+#define NODE_NAME "DummyModuleNode"
+// @endcond
+
+DummyModuleNode::DummyModuleNode(int equipletID, int moduleID) : rexos_mast::StateMachine(equipletID, moduleID) {
+	std::cout << "Constructing DummyModuleNode. EquipletID: " << equipletID << "ModuleID: " << moduleID << std::endl;
+
+	ros::NodeHandle nodeHandle;
+
+	outputCoordsService = nodeHandle.advertiseService(DummyModuleNodeServices::OUTPUTCOORDS, &DummyModuleNode::outputCoords, this);
+}
+
+bool DummyModuleNode::outputCoords(rexos_std_srvs::Module::Request &req, rexos_std_srvs::Module::Response &res){
+	ROS_INFO("outputCoords called");
+	std::cout << std::string(req.json) << std::endl;
+	return true;
+}
+
+int DummyModuleNode::transitionSetup(){
+	ROS_INFO("Setup transition called");
+	setState(rexos_mast::setup);
+
+	return 0;
+}
+
+int DummyModuleNode::transitionShutdown(){
+	ROS_INFO("Shutdown transition called");
+	setState(rexos_mast::shutdown);
+
+	return 0;
+}
+
+int DummyModuleNode::transitionStart(){
+	ROS_INFO("Start transition called");
+	setState(rexos_mast::start);
+
+	return 0;
+}
+
+int DummyModuleNode::transitionStop(){
+	ROS_INFO("Stop transition called");
+	setState(rexos_mast::stop);
+	
+	return 0;
+}
+
+DummyModuleNode::~DummyModuleNode(){
+	ROS_INFO("Destructing");
+}
+
+int main(int argc, char **argv){
+	int equipletID = 0;
+	int moduleID = 0;
+
+	if(argc < 3 || !(rexos_utilities::stringToInt(equipletID, argv[1]) == 0 && rexos_utilities::stringToInt(moduleID, argv[2]) == 0)){ 	 	
+		ROS_INFO("Cannot read equiplet id and/or moduleId from commandline please use correct values.");
+		return -1;
+	}
+
+	ros::init(argc, argv, NODE_NAME);
+
+	ROS_INFO("Creating Dummy Module");
+
+	DummyModuleNode dummy(equipletID, moduleID);
+
+	ROS_INFO("Running StateEngine");
+	ros::spin();
+	return 0;
+}


### PR DESCRIPTION
Added a dummy module node with a simple service and the MAST state machine. Multiple instances of it can be running at the same time if they have different equiplet and/or module IDs.
