### PR TITLE
Fixed issue with multiple updates.

### DIFF
--- a/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
+++ b/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
@@ -33,15 +33,22 @@
 
 package rexos.libraries.blackboard_client;
 
-import com.mongodb.*;
-import com.mongodb.util.JSON;
-import com.mongodb.util.JSONParseException;
-
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.bson.types.ObjectId;
+
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.Mongo;
+import com.mongodb.MongoException;
+import com.mongodb.QueryBuilder;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteResult;
+import com.mongodb.util.JSON;
+import com.mongodb.util.JSONParseException;
 
 /**
  * Client class for a mongodb blackboard.
@@ -382,7 +389,7 @@ public class BlackboardClient {
 		}
 		
 		try {
-			WriteResult res = currentCollection.update(searchQuery, updateQuery);
+			WriteResult res = currentCollection.updateMulti(searchQuery, updateQuery);
 			return res.getN();
 		} catch (MongoException mongoException) {
 			throw new GeneralMongoException("An error occurred attempting to update.", mongoException);


### PR DESCRIPTION
Apparently DBCollection.update with two DBObject parameters does not perform a 'multi' update, resulting in only one document being updated per call. Changed to updateMulti instead.
