### PR TITLE
Blackboard client dev

### DIFF
--- a/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
+++ b/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
@@ -46,6 +46,7 @@ import com.mongodb.Mongo;
 import com.mongodb.MongoException;
 import com.mongodb.QueryBuilder;
 import com.mongodb.ServerAddress;
+import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
 import com.mongodb.util.JSON;
 import com.mongodb.util.JSONParseException;
@@ -227,6 +228,31 @@ public class BlackboardClient {
 			throw new GeneralMongoException("An error occurred attempting to insert.", mongoException);
 		}
 		return ObjectId.massageToObjectId(obj.get("_id"));
+	}
+	
+	public void insertDocuments(DBObject... objs) throws InvalidDBNamespaceException, GeneralMongoException {
+		if (currentCollection == null) {
+			throw new InvalidDBNamespaceException("No collection has been selected.");
+		}
+		try {
+			currentCollection.insert(objs);
+		} catch (MongoException mongoException) {
+			throw new GeneralMongoException("An error occurred attempting to insert.", mongoException);
+		}
+	}
+	
+	public void insertDocumentsUnsafe(DBObject... objs) throws InvalidDBNamespaceException, GeneralMongoException {
+		if (currentCollection == null) {
+			throw new InvalidDBNamespaceException("No collection has been selected.");
+		}
+		try {
+			WriteConcern oldConcern = currentCollection.getWriteConcern();
+			currentCollection.setWriteConcern(WriteConcern.NORMAL);
+			currentCollection.insert(objs);
+			currentCollection.setWriteConcern(oldConcern);
+		} catch (MongoException mongoException) {
+			throw new GeneralMongoException("An error occurred attempting to insert.", mongoException);
+		}
 	}
 	
 	/**

--- a/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
+++ b/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
@@ -230,6 +230,21 @@ public class BlackboardClient {
 		return ObjectId.massageToObjectId(obj.get("_id"));
 	}
 	
+	public ObjectId insertDocumentUnsafe(DBObject obj) throws InvalidDBNamespaceException, GeneralMongoException {
+		if (currentCollection == null) {
+			throw new InvalidDBNamespaceException("No collection has been selected.");
+		}
+		try {
+			WriteConcern oldConcern = currentCollection.getWriteConcern();
+			currentCollection.setWriteConcern(WriteConcern.NORMAL);
+			currentCollection.insert(obj);
+			currentCollection.setWriteConcern(oldConcern);
+		} catch (MongoException mongoException) {
+			throw new GeneralMongoException("An error occurred attempting to insert.", mongoException);
+		}
+		return ObjectId.massageToObjectId(obj.get("_id"));
+	}
+	
 	public void insertDocuments(DBObject... objs) throws InvalidDBNamespaceException, GeneralMongoException {
 		if (currentCollection == null) {
 			throw new InvalidDBNamespaceException("No collection has been selected.");

--- a/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
+++ b/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
@@ -230,6 +230,15 @@ public class BlackboardClient {
 		return ObjectId.massageToObjectId(obj.get("_id"));
 	}
 	
+	/**
+	 * Inserts a document into the currently selected collection.
+	 * Does not wait for the server to perform write to disk, nor does it check for errors other than networks errors.
+	 * 
+	 * @param obj DBObject representing the document to be inserted.
+	 * @return ObjectId of the inserted object.
+	 * @throws InvalidDBNamespaceException No collection has been selected.
+	 * @throws GeneralMongoException A MongoException occurred.
+	 **/
 	public ObjectId insertDocumentUnsafe(DBObject obj) throws InvalidDBNamespaceException, GeneralMongoException {
 		if (currentCollection == null) {
 			throw new InvalidDBNamespaceException("No collection has been selected.");
@@ -245,6 +254,13 @@ public class BlackboardClient {
 		return ObjectId.massageToObjectId(obj.get("_id"));
 	}
 	
+	/**
+	 * Inserts a number of documents into the currently selected collection.
+	 * 
+	 * @param objs DBObjects that should be inserted into the database.
+	 * @throws InvalidDBNamespaceException No collection has been selected.
+	 * @throws GeneralMongoException A MongoException occurred.
+	 **/
 	public void insertDocuments(DBObject... objs) throws InvalidDBNamespaceException, GeneralMongoException {
 		if (currentCollection == null) {
 			throw new InvalidDBNamespaceException("No collection has been selected.");
@@ -256,6 +272,14 @@ public class BlackboardClient {
 		}
 	}
 	
+	/**
+	 * Inserts a number of documents into the currently selected collection.
+	 * Does not wait for the server to perform write to disk, nor does it check for errors other than networks errors.
+	 *
+	 * @param objs DBObjects that should be inserted into the database.
+	 * @throws InvalidDBNamespaceException No collection has been selected.
+	 * @throws GeneralMongoException A MongoException occurred.
+	 **/
 	public void insertDocumentsUnsafe(DBObject... objs) throws InvalidDBNamespaceException, GeneralMongoException {
 		if (currentCollection == null) {
 			throw new InvalidDBNamespaceException("No collection has been selected.");
@@ -304,6 +328,29 @@ public class BlackboardClient {
 			throw new GeneralMongoException("An error occurred attempting to remove.", mongoException);
 		}
 		
+	}
+	
+	/**
+	 * Removes all documents matching the provided query from the currently selected collection.
+	 * Does not wait for the server to perform write to disk, nor does it check for errors other than networks errors.
+	 *
+	 * @param query DBObject representing the query used for deleting documents.
+	 * @throws InvalidDBNamespaceException No collection has been selected.
+	 * @throws GeneralMongoException A MongoException occurred.
+	 **/
+	public void removeDocumentsUnsafe(DBObject query) throws InvalidDBNamespaceException, GeneralMongoException {
+		if (currentCollection == null) {
+			throw new InvalidDBNamespaceException("No collection has been selected.");
+		}
+		
+		try {
+			WriteConcern oldConcern = currentCollection.getWriteConcern();
+			currentCollection.setWriteConcern(WriteConcern.NORMAL);
+			currentCollection.remove(query);
+			currentCollection.setWriteConcern(oldConcern);
+		} catch (MongoException mongoException) {
+			throw new GeneralMongoException("An error occurred attempting to remove.", mongoException);
+		}
 	}
 	
 	/**
@@ -437,6 +484,17 @@ public class BlackboardClient {
 		}
 	}
 	
+	/**
+	 * Updates all documents matching the provided search query within the currently selected collection.
+	 * Documents are updated according to the query specified in updateQuery.
+	 * Does not wait for the server to perform write to disk, nor does it check for errors other than networks errors.
+	 * 
+	 * @param searchQuery The query that should be used to select the target documents.
+	 * @param updateQuery The query that should be used to update the target documents.
+	 * @return The amount of documents that have been updated.
+	 * @throws InvalidDBNamespaceException No collection has been selected.
+	 * @throws GeneralMongoException A MongoException occurred.
+	 **/
 	public void updateDocumentsUnsafe(DBObject searchQuery, DBObject updateQuery) throws InvalidDBNamespaceException, GeneralMongoException {
 		if (currentCollection == null) {
 			throw new InvalidDBNamespaceException("No collection has been selected.");

--- a/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
+++ b/src/java/rexos/libraries/blackboard_client/BlackboardClient.java
@@ -437,6 +437,21 @@ public class BlackboardClient {
 		}
 	}
 	
+	public void updateDocumentsUnsafe(DBObject searchQuery, DBObject updateQuery) throws InvalidDBNamespaceException, GeneralMongoException {
+		if (currentCollection == null) {
+			throw new InvalidDBNamespaceException("No collection has been selected.");
+		}
+		
+		try {
+			WriteConcern oldConcern = currentCollection.getWriteConcern();
+			currentCollection.setWriteConcern(WriteConcern.NORMAL);
+			currentCollection.updateMulti(searchQuery, updateQuery);
+			currentCollection.setWriteConcern(oldConcern);
+		} catch (MongoException mongoException) {
+			throw new GeneralMongoException("An error occurred attempting to update.", mongoException);
+		}
+	}
+	
 	/**
 	 * Updates all documents matching the provided search query within the currently selected collection.
 	 * Documents are updated according to the query specified in updateQuery.

--- a/src/java/rexos/libraries/blackboard_client/OplogCallbackThread.java
+++ b/src/java/rexos/libraries/blackboard_client/OplogCallbackThread.java
@@ -1,0 +1,144 @@
+/**
+ * @file OplogCallbackThread.java
+ * @brief Asynchronously handles callbacks.
+ * @date Created: 28 jun. 2013
+ *
+ * @author Jan-Willem Willebrands
+ *
+ * @section LICENSE
+ * License: newBSD
+ *
+ * Copyright © 2013, HU University of Applied Sciences Utrecht.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the HU University of Applied Sciences Utrecht nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE HU UNIVERSITY OF APPLIED SCIENCES UTRECHT
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+package rexos.libraries.blackboard_client;
+
+import java.util.Stack;
+
+/**
+ * Simple data object used to store information about a callback.
+ */
+class Callback {
+	/**
+	 * @var BlackboardSubscriber subscriber
+	 * The subscriber that should receive a callback.
+	 */
+	BlackboardSubscriber subscriber;
+	
+	/**
+	 * @var OplogEntry entry
+	 * The OplogEntry describing the event that triggered this callback.
+	 */
+	OplogEntry entry;
+	
+	/**
+	 * Constructs a callback with the specified subscriber and entry.
+	 * 
+	 * @param subscriber The subscriber that should receive a callback.
+	 * @param entry The OplogEntry describing the event that triggered this callback.
+	 *
+	 */
+	public Callback(BlackboardSubscriber subscriber, OplogEntry entry) {
+		this.subscriber = subscriber;
+		this.entry = entry;
+	}
+
+	/**
+	 * Returns the subscriber for this callback.
+	 * @return The subscriber for this callback.
+	 */
+	public BlackboardSubscriber getSubscriber() {
+		return subscriber;
+	}
+
+	/**
+	 * Returns the entry for this callback.
+	 * 
+	 * @return The entry for this callback.
+	 */
+	public OplogEntry getEntry() {
+		return entry;
+	}
+}
+
+/**
+ * Asynchronously handles callbacks.
+ **/
+public class OplogCallbackThread extends Thread {
+	/**
+	 * @var Stack<Callback> callbacks
+	 * List of callbacks that need to be handled.
+	 */
+	private Stack<Callback> callbacks;
+	
+	/**
+	 * @var boolean running
+	 * Current running state of the callback thread.
+	 */
+	private boolean running = true;
+	
+	/**
+	 * Constructs and starts a new thread.
+	 */
+	public OplogCallbackThread() {
+		callbacks = new Stack<Callback>();
+		start();
+	}
+	
+	/**
+	 * Adds a callback to the list and notifies the thread.
+	 * 
+	 * @param subscriber The subscriber that should receive a callback.
+	 * @param entry The OplogEntry describing the event that triggered this callback.
+	 *
+	 */
+	public synchronized void addCallback(BlackboardSubscriber subscriber, OplogEntry entry) {
+		Callback callback = new Callback(subscriber, entry);
+		callbacks.push(callback);
+		notifyAll();
+	}
+	
+	/**
+	 * Sets the current running state to false and notifies the thread.
+	 */
+	public synchronized void shutdown() {
+		running = false;
+		notifyAll();
+	}
+	
+	/**
+	 * Waits for callbacks to be added and handles them.
+	 **/
+	@Override
+	public synchronized void run() {
+		while (running) {
+			if (callbacks.empty()) {
+				try {
+					wait();
+				} catch (InterruptedException ex) {}
+			} else {
+				while (!callbacks.empty()) {
+					Callback callback = callbacks.pop();
+					
+					callback.getSubscriber().onMessage(callback.getEntry().getOperation(), callback.getEntry());
+				}
+			}
+		}
+	}
+}

--- a/src/java/rexos/libraries/blackboard_client/OplogMonitorThread.java
+++ b/src/java/rexos/libraries/blackboard_client/OplogMonitorThread.java
@@ -122,7 +122,7 @@ class OplogMonitorThread extends Thread {
 	@Override
 	public void run() {
 		try {
-			while (!Thread.interrupted() && tailedCursor.getCursorId() != 0) {
+			do {
 				while (!Thread.interrupted() && tailedCursor.hasNext()) {
 					OplogEntry entry = new OplogEntry(tailedCursor.next());
 					MongoOperation operation = entry.getOperation();
@@ -135,7 +135,7 @@ class OplogMonitorThread extends Thread {
 				}
 				
 				Thread.sleep(POLL_INTERVAL);
-			}
+			} while (!Thread.interrupted() && tailedCursor.getCursorId() != 0);
 		} catch (MongoInterruptedException | MongoException.CursorNotFound | InterruptedException ex) {
 			/*
 			 * MongoInterruptedException is thrown by Mongo when interrupt is called while blocking on the

--- a/src/java/rexos/libraries/blackboard_client/OplogMonitorThread.java
+++ b/src/java/rexos/libraries/blackboard_client/OplogMonitorThread.java
@@ -46,6 +46,14 @@ import com.mongodb.MongoInterruptedException;
 class OplogMonitorThread extends Thread {
 	
 	/**
+	 * @var int POLL_INTERVAL
+	 * The interval between two checks for new documents in milliseconds. Note that this interval is not used
+	 * when there are multiple documents available. In this case all documents will be retrieved after which
+	 * the thread will sleep for this interval when no more documents are available.
+	 **/
+	private static final int POLL_INTERVAL = 100;
+
+	/**
 	 * @var DBCursor tailedCursor
 	 * Tailed cursor for this thread.
 	 **/
@@ -126,7 +134,7 @@ class OplogMonitorThread extends Thread {
 					}
 				}
 				
-				Thread.sleep(100);
+				Thread.sleep(POLL_INTERVAL);
 			}
 		} catch (MongoInterruptedException | MongoException.CursorNotFound | InterruptedException ex) {
 			/*

--- a/src/java/rexos/libraries/blackboard_client/OplogMonitorThread.java
+++ b/src/java/rexos/libraries/blackboard_client/OplogMonitorThread.java
@@ -59,6 +59,7 @@ class OplogMonitorThread extends Thread {
 	
 	/**
 	 * Constructor of OplogMonitorThread.
+	 * @param mongo The Mongo database connection that should be used.
 	 * @param oplogDBName The database in which the oplog collection resides.
 	 * @param oplogCollectionName The name of the oplog collection.
 	 * @param query The query that will be used in the tailed cursor.
@@ -77,6 +78,7 @@ class OplogMonitorThread extends Thread {
 	 * Constructs a tailed cursor for the specified query on the oplog collection.
 	 * This constructor should be used when user authentication is required.
 	 * 
+	 * @param mongo The Mongo database connection that should be used.
 	 * @param oplogDBName The database in which the oplog collection resides.
 	 * @param oplogCollectionName The name of the oplog collection.
 	 * @param username Username that will be used to authenticate with the oplog database. This user should have read access.

--- a/src/java/rexos/libraries/build.xml
+++ b/src/java/rexos/libraries/build.xml
@@ -5,17 +5,22 @@
 	<target name="all" depends="blackboard_client, knowledgedb_client"> 
 	</target>
 
-	<target name="blackboard_client">
+	<target name="blackboard_client" depends="log">
 		<ant antfile="build.xml" target="build" dir="blackboard_client" inheritRefs="true" useNativeBasedir="true"/>  
 	</target>
 
 	<target name="knowledgedb_client">
 		<ant antfile="build.xml" target="build" dir="knowledgedb_client" inheritRefs="true" useNativeBasedir="true"/>  
 	</target>
+	
+	<target name="log">
+		<ant antfile="build.xml" target="build" dir="log" inheritRefs="true" useNativeBasedir="true"/>  
+	</target>
 
 	<target name="clean">
 		<ant antfile="build.xml" target="clean" dir="blackboard_client" inheritRefs="true" useNativeBasedir="true"/> 
-		<ant antfile="build.xml" target="clean" dir="knowledgedb_client" inheritRefs="true" useNativeBasedir="true"/>   
+		<ant antfile="build.xml" target="clean" dir="knowledgedb_client" inheritRefs="true" useNativeBasedir="true"/>
+		<ant antfile="build.xml" target="clean" dir="log" inheritRefs="true" useNativeBasedir="true"/> 
 	</target>
 
 </project>

--- a/src/java/rexos/libraries/log/Logger.java
+++ b/src/java/rexos/libraries/log/Logger.java
@@ -1,0 +1,104 @@
+/**
+ * @file Logger.java
+ * @brief Helper for log messages, providing a single point for controlling program output.
+ * @date Created: 17 mei 2013
+ *
+ * @author Jan-Willem Willebrands
+ *
+ * @section LICENSE
+ * License: newBSD
+ *
+ * Copyright © 2013, HU University of Applied Sciences Utrecht.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of the HU University of Applied Sciences Utrecht nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE HU UNIVERSITY OF APPLIED SCIENCES UTRECHT
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+package rexos.libraries.log;
+
+import java.io.PrintStream;
+
+/**
+ * Helper for log messages, providing a single point for controlling program output.
+ **/
+public class Logger {
+	/**
+	 * @var PrintStream errStream
+	 * Stream that will be used for writing error messages, i.e. throwables.
+	 **/
+	private static final PrintStream errStream = System.err;
+	
+	/**
+	 * @var PrintStream outStream
+	 * Stream that will be used for writing log messages.
+	 **/
+	private static final PrintStream outStream = System.out;
+	
+	/**
+	 * @var boolean debugEnabled
+	 * Controls whether or not printing of log messages is enabled.
+	 **/
+	private static final boolean debugEnabled = true;
+	
+	/**
+	 * Returns whether or not debugging is enabled.
+	 * @return true if debugging is enabled, false otherwise.
+	 **/
+	public static boolean isDebugEnabled() {
+		return debugEnabled;
+	}
+	
+	/**
+	 * Writes the String representation (as returned by obj.toString) of the given object to the output stream.
+	 * @param obj The Object that should be printed.
+	 **/
+	public static void log(Object obj) {
+		if (debugEnabled) {
+			outStream.println(obj.toString());
+		}
+	}
+	
+	/**
+	 * Writes the specified message to the output stream.
+	 * @param msg The message that should be printed.
+	 **/
+	public static void log(String msg) {
+		if (debugEnabled) {
+			outStream.println(msg);
+		}
+	}
+	
+	/**
+	 * Writes the specified message to the output stream using the PrintStream format method.
+	 * @param msg A format string as described in http://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html
+	 * @param objects Arguments referenced by the format specifiers in the format string.
+	 **/
+	public static void log(String msg, Object... objects) {
+		if (debugEnabled) {
+			outStream.format(msg, objects);
+		}
+	}
+	
+	/**
+	 * Prints the stacktrace for the specified throwable to the error stream.
+	 * @param throwable The throwable that should be printed.
+	 **/
+	public static void log(Throwable throwable) {
+		if (debugEnabled) {
+			throwable.printStackTrace(errStream);
+		}
+	}
+}

--- a/src/java/rexos/libraries/log/build.xml
+++ b/src/java/rexos/libraries/log/build.xml
@@ -1,0 +1,14 @@
+<project name="log" default="build" basedir=".">
+
+	<import file="../build.xml"/>
+
+	<target name="build"> 			
+		<!-- defined in the root build.xml -->
+		<buildjava dir="${basedir}"/>  
+	</target>
+
+	<target name="clean">
+		 <cleanjava dir="${basedir}"/>
+	</target>
+
+</project>


### PR DESCRIPTION
Added utility method for inserting an array of documents. 

Also added 'unsafe' methods that do not use the default SAFE WriteConcern. These methods adhere to the fire and forget philosophy of Mongo in that they do not wait for any confirmation from the server that the operation has been written to disk nor what the result was. These methods can be used in timing critical situations where confirmation is not required.

Additionally the OplogMonitorThread dies in a cleaner way, catching any stray exceptions that may be thrown by mongo during the interruption process.
